### PR TITLE
Update client when a block break event is canceled.

### DIFF
--- a/src/main/java/nerdhub/textilelib/mixins/MixinServerPlayerInteractionManager.java
+++ b/src/main/java/nerdhub/textilelib/mixins/MixinServerPlayerInteractionManager.java
@@ -3,6 +3,7 @@ package nerdhub.textilelib.mixins;
 import nerdhub.textilelib.eventhandlers.EventRegistry;
 import nerdhub.textilelib.events.BlockEvent;
 import nerdhub.textilelib.events.PlayerEvent;
+import net.minecraft.client.network.packet.BlockUpdateClientPacket;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -35,6 +36,11 @@ public class MixinServerPlayerInteractionManager {
         if (blockBreakEvent.isCanceled()) {
             cir.setReturnValue(false);
             cir.cancel();
+
+            // Update client as they will believe they have broken the block.
+            if(player != null) {
+                this.player.networkHandler.sendPacket(new BlockUpdateClientPacket(world, blockPos_1));
+            }
         }
     }
 


### PR DESCRIPTION
If a block break event is canceled the client wwill still sometimes think on their side it is broken. Sending a packet back to the client with the current state to fix that issue.