### PR TITLE
Added DebugText & DrawHud Events

### DIFF
--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/DebugHudTextCallback.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/DebugHudTextCallback.java
@@ -1,0 +1,27 @@
+package nerdhub.textilelib.event.client.render.hud;
+
+import java.util.List;
+
+import net.minecraft.client.gui.hud.DebugHud;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+@Environment(EnvType.CLIENT)
+public interface DebugHudTextCallback {
+
+    Event<DebugHudTextCallback> EVENT = EventFactory.createArrayBacked(DebugHudTextCallback.class, listeners -> (List<String> list, Side side) -> {
+        for (DebugHudTextCallback callback : listeners) {
+            callback.getText(list, side);
+        }
+    });
+
+    /**
+     * Called after the {@link DebugHud} has collected the list of strings to draw, to allow for rendering additional information
+     */
+    void getText(List<String> list, Side side);
+
+    enum Side {LEFT, RIGHT}
+}

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/DrawHudCallback.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/DrawHudCallback.java
@@ -10,14 +10,28 @@ import net.fabricmc.fabric.api.event.EventFactory;
 @Environment(EnvType.CLIENT)
 public interface DrawHudCallback {
 
-    Event<DrawHudCallback> EVENT = EventFactory.createArrayBacked(DrawHudCallback.class, listeners -> (type, hud, mouseX, mouseY, deltaTime) -> {
+    Event<DrawHudCallback> EVENT_BEFORE = EventFactory.createArrayBacked(DrawHudCallback.class, listeners -> (type, hud, deltaTime) -> {
         for (DrawHudCallback callback : listeners) {
-            callback.drawHud(type, hud, mouseX, mouseY, deltaTime);
+            if (!callback.drawHud(type, hud, deltaTime)) {
+                return false;
+            }
         }
+        return true;
+    });
+
+    Event<DrawHudCallback> EVENT_AFTER = EventFactory.createArrayBacked(DrawHudCallback.class, listeners -> (type, hud, deltaTime) -> {
+        for (DrawHudCallback callback : listeners) {
+            if (!callback.drawHud(type, hud, deltaTime)) {
+                return false;
+            }
+        }
+        return true;
     });
 
     /**
-     * Called after the {@link DrawableHelper} is drawn, to allow for rendering additional elements
+     * Called before and after the {@link DrawableHelper} is drawn, to allow for rendering additional elements
+     *
+     * @return True to continue drawing, False to finish/cancel drawing
      */
-    void drawHud(IHudType type, DrawableHelper hud, int mouseX, int mouseY, float deltaTime);
+    boolean drawHud(IHudType type, DrawableHelper hud, float deltaTime);
 }

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/DrawHudCallback.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/DrawHudCallback.java
@@ -1,0 +1,23 @@
+package nerdhub.textilelib.event.client.render.hud;
+
+import net.minecraft.client.gui.DrawableHelper;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+
+@Environment(EnvType.CLIENT)
+public interface DrawHudCallback {
+
+    Event<DrawHudCallback> EVENT = EventFactory.createArrayBacked(DrawHudCallback.class, listeners -> (type, hud, mouseX, mouseY, deltaTime) -> {
+        for (DrawHudCallback callback : listeners) {
+            callback.drawHud(type, hud, mouseX, mouseY, deltaTime);
+        }
+    });
+
+    /**
+     * Called after the {@link DrawableHelper} is drawn, to allow for rendering additional elements
+     */
+    void drawHud(IHudType type, DrawableHelper hud, int mouseX, int mouseY, float deltaTime);
+}

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/DrawHudCallback.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/DrawHudCallback.java
@@ -10,28 +10,36 @@ import net.fabricmc.fabric.api.event.EventFactory;
 @Environment(EnvType.CLIENT)
 public interface DrawHudCallback {
 
-    Event<DrawHudCallback> EVENT_BEFORE = EventFactory.createArrayBacked(DrawHudCallback.class, listeners -> (type, hud, deltaTime) -> {
-        for (DrawHudCallback callback : listeners) {
-            if (!callback.drawHud(type, hud, deltaTime)) {
-                return false;
-            }
-        }
-        return true;
-    });
+    interface Pre extends DrawHudCallback {
 
-    Event<DrawHudCallback> EVENT_AFTER = EventFactory.createArrayBacked(DrawHudCallback.class, listeners -> (type, hud, deltaTime) -> {
-        for (DrawHudCallback callback : listeners) {
-            if (!callback.drawHud(type, hud, deltaTime)) {
-                return false;
+        Event<Pre> EVENT = EventFactory.createArrayBacked(Pre.class, listeners -> (type, hud, deltaTime) -> {
+            for (Pre callback : listeners) {
+                if (!callback.drawHud(type, hud, deltaTime)) {
+                    return false;
+                }
             }
-        }
-        return true;
-    });
+            return true;
+        });
 
-    /**
-     * Called before and after the {@link DrawableHelper} is drawn, to allow for rendering additional elements
-     *
-     * @return True to continue drawing, False to finish/cancel drawing
-     */
-    boolean drawHud(IHudType type, DrawableHelper hud, float deltaTime);
+        /**
+         * Called before the {@link DrawableHelper} is drawn, to allow for rendering additional elements
+         *
+         * @return True to continue drawing, False to finish/cancel drawing
+         */
+        boolean drawHud(IHudType type, DrawableHelper hud, float deltaTime);
+    }
+
+    interface Post extends DrawHudCallback {
+
+        Event<Post> EVENT = EventFactory.createArrayBacked(Post.class, listeners -> (type, hud, deltaTime) -> {
+            for (Post callback : listeners) {
+                callback.drawHud(type, hud, deltaTime);
+            }
+        });
+
+        /**
+         * Called after the {@link DrawableHelper} is drawn, to allow for rendering additional elements
+         */
+        void drawHud(IHudType type, DrawableHelper hud, float deltaTime);
+    }
 }

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/HudTypes.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/HudTypes.java
@@ -12,8 +12,5 @@ public enum HudTypes implements IHudType {
     CHAT,
     SCOREBOARD,
     SUBTITLES,
-    HEALTH,
-    FOOD,
-    ARMOR,
-    AIR
+    STATUSBARS
 }

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/HudTypes.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/HudTypes.java
@@ -11,5 +11,9 @@ public enum HudTypes implements IHudType {
     BOSSBAR,
     CHAT,
     SCOREBOARD,
-    SUBTITLES
+    SUBTITLES,
+    HEALTH,
+    FOOD,
+    ARMOR,
+    AIR
 }

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/HudTypes.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/HudTypes.java
@@ -4,7 +4,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
 @Environment(EnvType.CLIENT)
-public enum VanillaHudTypes implements IHudType {
+public enum HudTypes implements IHudType {
     INGAME,
     SPECTATOR,
     DEBUG,

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/IHudType.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/IHudType.java
@@ -1,0 +1,9 @@
+package nerdhub.textilelib.event.client.render.hud;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public interface IHudType {
+
+}

--- a/src/main/java/nerdhub/textilelib/event/client/render/hud/VanillaHudTypes.java
+++ b/src/main/java/nerdhub/textilelib/event/client/render/hud/VanillaHudTypes.java
@@ -1,0 +1,15 @@
+package nerdhub.textilelib.event.client.render.hud;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+
+@Environment(EnvType.CLIENT)
+public enum VanillaHudTypes implements IHudType {
+    INGAME,
+    SPECTATOR,
+    DEBUG,
+    BOSSBAR,
+    CHAT,
+    SCOREBOARD,
+    SUBTITLES
+}

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinDebugHud.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinDebugHud.java
@@ -1,0 +1,25 @@
+package nerdhub.textilelib.mixin.client;
+
+import java.util.List;
+
+import net.minecraft.client.gui.hud.DebugHud;
+
+import nerdhub.textilelib.event.client.render.hud.DebugHudTextCallback;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(DebugHud.class)
+public abstract class MixinDebugHud {
+
+    @Inject(method = "getLeftText", at = @At("RETURN"))
+    private void getLeftText(CallbackInfoReturnable<List<String>> cir) {
+        DebugHudTextCallback.EVENT.invoker().getText(cir.getReturnValue(), DebugHudTextCallback.Side.LEFT);
+    }
+
+    @Inject(method = "getRightText", at = @At("RETURN"))
+    private void getRightText(CallbackInfoReturnable<List<String>> cir) {
+        DebugHudTextCallback.EVENT.invoker().getText(cir.getReturnValue(), DebugHudTextCallback.Side.RIGHT);
+    }
+}

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinGameRenderer.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinGameRenderer.java
@@ -6,7 +6,7 @@ import net.minecraft.client.render.GameRenderer;
 import nerdhub.textilelib.event.client.render.DrawScreenCallback;
 import nerdhub.textilelib.event.client.render.RenderWorldCallback;
 import nerdhub.textilelib.event.client.render.hud.DrawHudCallback;
-import nerdhub.textilelib.event.client.render.hud.VanillaHudTypes;
+import nerdhub.textilelib.event.client.render.hud.HudTypes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,20 +23,23 @@ public abstract class MixinGameRenderer {
 
     @Inject(at = @At(value = "INVOKE_STRING", target = "Lnet/minecraft/util/profiler/Profiler;swap(Ljava/lang/String;)V", args = "ldc=entities", shift = At.Shift.BEFORE), method = "renderCenter")
     private void renderCenter(float deltaTime, long long_1, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_world");
+        this.client.getProfiler().push("textilelib:renderWorld");
         RenderWorldCallback.EVENT.invoker().render(this.client.worldRenderer, deltaTime);
+        this.client.getProfiler().pop();
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Screen;draw(IIF)V", shift = At.Shift.AFTER), method = "render")
     private void renderScreen(float deltaTime, long long_1, boolean boolean_1, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_screen");
+        this.client.getProfiler().push("textilelib:renderScreen");
         DrawScreenCallback.EVENT.invoker().drawScreen(this.client.currentScreen, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;draw(F)V", shift = At.Shift.AFTER), method = "render")
     private void renderInGameHud(float deltaTime, long long_1, boolean boolean_1, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_hud_ingame");
-        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.INGAME, this.client.inGameHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudIngame");
+        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.INGAME, this.client.inGameHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     private int getMouseX() {

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinGameRenderer.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinGameRenderer.java
@@ -40,11 +40,11 @@ public abstract class MixinGameRenderer {
     @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;draw(F)V"), method = "render")
     private void renderInGameHud(InGameHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudIngameBefore");
-        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.INGAME, hud, deltaTime)) {
+        if (DrawHudCallback.Pre.EVENT.invoker().drawHud(HudTypes.INGAME, hud, deltaTime)) {
             this.client.getProfiler().swap("textilelib:renderHudIngameDraw");
             hud.draw(deltaTime);
             this.client.getProfiler().swap("textilelib:renderHudIngameAfter");
-            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.INGAME, hud, deltaTime);
+            DrawHudCallback.Post.EVENT.invoker().drawHud(HudTypes.INGAME, hud, deltaTime);
         }
         this.client.getProfiler().pop();
     }

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinGameRenderer.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinGameRenderer.java
@@ -1,8 +1,12 @@
 package nerdhub.textilelib.mixin.client;
 
-import nerdhub.textilelib.event.client.render.RenderWorldCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.GameRenderer;
+
+import nerdhub.textilelib.event.client.render.DrawScreenCallback;
+import nerdhub.textilelib.event.client.render.RenderWorldCallback;
+import nerdhub.textilelib.event.client.render.hud.DrawHudCallback;
+import nerdhub.textilelib.event.client.render.hud.VanillaHudTypes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -21,5 +25,25 @@ public abstract class MixinGameRenderer {
     private void renderCenter(float deltaTime, long long_1, CallbackInfo ci) {
         this.client.getProfiler().swap("textilelib_render_world");
         RenderWorldCallback.EVENT.invoker().render(this.client.worldRenderer, deltaTime);
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/Screen;draw(IIF)V", shift = At.Shift.AFTER), method = "render")
+    private void renderScreen(float deltaTime, long long_1, boolean boolean_1, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_screen");
+        DrawScreenCallback.EVENT.invoker().drawScreen(this.client.currentScreen, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;draw(F)V", shift = At.Shift.AFTER), method = "render")
+    private void renderInGameHud(float deltaTime, long long_1, boolean boolean_1, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_hud_ingame");
+        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.INGAME, this.client.inGameHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    private int getMouseX() {
+        return (int) (this.client.mouse.getX() * (double) this.client.window.getScaledWidth() / (double) this.client.window.getWidth());
+    }
+
+    private int getMouseY() {
+        return (int) (this.client.mouse.getY() * (double) this.client.window.getScaledHeight() / (double) this.client.window.getHeight());
     }
 }

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
@@ -26,11 +26,11 @@ public abstract class MixinInGameHud {
     private void drawSpectatorHud(SpectatorHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudSpectator");
         this.client.getProfiler().push("textilelib:renderHudSpectatorBefore");
-        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.SPECTATOR, hud, deltaTime)) {
+        if (DrawHudCallback.Pre.EVENT.invoker().drawHud(HudTypes.SPECTATOR, hud, deltaTime)) {
             this.client.getProfiler().swap("textilelib:renderHudSpectatorDraw");
             hud.draw(deltaTime);
             this.client.getProfiler().swap("textilelib:renderHudSpectatorAfter");
-            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.SPECTATOR, hud, deltaTime);
+            DrawHudCallback.Post.EVENT.invoker().drawHud(HudTypes.SPECTATOR, hud, deltaTime);
         }
         this.client.getProfiler().pop();
         this.client.getProfiler().pop();
@@ -39,11 +39,11 @@ public abstract class MixinInGameHud {
     @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/BossBarHud;draw()V"), method = "draw")
     private void drawBossBarHud(BossBarHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudBossbarBefore");
-        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.BOSSBAR, hud, deltaTime)) {
+        if (DrawHudCallback.Pre.EVENT.invoker().drawHud(HudTypes.BOSSBAR, hud, deltaTime)) {
             this.client.getProfiler().swap("textilelib:renderHudBossbarDraw");
             hud.draw();
             this.client.getProfiler().swap("textilelib:renderHudBossbarAfter");
-            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.BOSSBAR, hud, deltaTime);
+            DrawHudCallback.Post.EVENT.invoker().drawHud(HudTypes.BOSSBAR, hud, deltaTime);
         }
         this.client.getProfiler().pop();
     }
@@ -52,11 +52,11 @@ public abstract class MixinInGameHud {
     private void drawDebugHud(DebugHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudDebug");
         this.client.getProfiler().push("textilelib:renderHudDebugBefore");
-        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.DEBUG, hud, deltaTime)) {
+        if (DrawHudCallback.Pre.EVENT.invoker().drawHud(HudTypes.DEBUG, hud, deltaTime)) {
             this.client.getProfiler().swap("textilelib:renderHudDebugDraw");
             hud.draw();
             this.client.getProfiler().swap("textilelib:renderHudDebugAfter");
-            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.DEBUG, hud, deltaTime);
+            DrawHudCallback.Post.EVENT.invoker().drawHud(HudTypes.DEBUG, hud, deltaTime);
         }
         this.client.getProfiler().pop();
         this.client.getProfiler().pop();
@@ -66,11 +66,11 @@ public abstract class MixinInGameHud {
     private void drawSubtitlesHud(SubtitlesHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudSubtitles");
         this.client.getProfiler().push("textilelib:renderHudSubtitlesBefore");
-        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.SUBTITLES, hud, deltaTime)) {
+        if (DrawHudCallback.Pre.EVENT.invoker().drawHud(HudTypes.SUBTITLES, hud, deltaTime)) {
             this.client.getProfiler().swap("textilelib:renderHudSubtitlesDraw");
             hud.draw();
             this.client.getProfiler().swap("textilelib:renderHudSubtitlesAfter");
-            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.SUBTITLES, hud, deltaTime);
+            DrawHudCallback.Post.EVENT.invoker().drawHud(HudTypes.SUBTITLES, hud, deltaTime);
         }
         this.client.getProfiler().pop();
         this.client.getProfiler().pop();
@@ -80,11 +80,11 @@ public abstract class MixinInGameHud {
     private void drawScoreboardHud(InGameHud hud, ScoreboardObjective scoreboardObjective, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudScoreboard");
         this.client.getProfiler().push("textilelib:renderHudScoreboardBefore");
-        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.SCOREBOARD, hud.getScoreboardWidget(), deltaTime)) {
+        if (DrawHudCallback.Pre.EVENT.invoker().drawHud(HudTypes.SCOREBOARD, hud.getScoreboardWidget(), deltaTime)) {
             this.client.getProfiler().swap("textilelib:renderHudScoreboardDraw");
             this.renderScoreboardSidebar(scoreboardObjective);
             this.client.getProfiler().swap("textilelib:renderHudScoreboardAfter");
-            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.SCOREBOARD, hud.getScoreboardWidget(), deltaTime);
+            DrawHudCallback.Post.EVENT.invoker().drawHud(HudTypes.SCOREBOARD, hud.getScoreboardWidget(), deltaTime);
         }
         this.client.getProfiler().pop();
         this.client.getProfiler().pop();
@@ -93,11 +93,11 @@ public abstract class MixinInGameHud {
     @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/ChatHud;draw(I)V"), method = "draw")
     private void drawChatHud(ChatHud hud, int int_1, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudChat");
-        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.CHAT, hud, deltaTime)) {
+        if (DrawHudCallback.Pre.EVENT.invoker().drawHud(HudTypes.CHAT, hud, deltaTime)) {
             this.client.getProfiler().swap("textilelib:renderHudChatDraw");
             hud.draw(int_1);
             this.client.getProfiler().swap("textilelib:renderHudChatAfter");
-            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.CHAT, hud, deltaTime);
+            DrawHudCallback.Post.EVENT.invoker().drawHud(HudTypes.CHAT, hud, deltaTime);
         }
         this.client.getProfiler().pop();
     }

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
@@ -1,0 +1,89 @@
+package nerdhub.textilelib.mixin.client;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.hud.*;
+
+import nerdhub.textilelib.event.client.render.hud.DrawHudCallback;
+import nerdhub.textilelib.event.client.render.hud.VanillaHudTypes;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InGameHud.class)
+public abstract class MixinInGameHud {
+
+    @Shadow
+    @Final
+    private MinecraftClient client;
+
+    @Shadow
+    @Final
+    private DebugHud debugHud;
+
+    @Shadow
+    @Final
+    private BossBarHud bossBarHud;
+
+    @Shadow
+    @Final
+    private SpectatorHud spectatorHud;
+
+    @Shadow
+    @Final
+    private SubtitlesHud subtitlesHud;
+
+    @Shadow
+    @Final
+    private ScoreboardHud scoreboardHud;
+
+    @Shadow
+    @Final
+    private ChatHud chatHud;
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SpectatorHud;draw(F)V", shift = At.Shift.AFTER), method = "draw")
+    private void drawSpectatorHud(float deltaTime, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_hud_spectator");
+        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.SPECTATOR, this.spectatorHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/BossBarHud;draw()V", shift = At.Shift.AFTER), method = "draw")
+    private void drawBossBarHud(float deltaTime, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_hud_bossbar");
+        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.BOSSBAR, this.bossBarHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/DebugHud;draw()V", shift = At.Shift.AFTER), method = "draw")
+    private void drawDebugHud(float deltaTime, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_hud_debug");
+        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.DEBUG, this.debugHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud;draw()V", shift = At.Shift.AFTER), method = "draw")
+    private void drawSubtitlesHud(float deltaTime, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_hud_subtitles");
+        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.SUBTITLES, this.subtitlesHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderScoreboardSidebar(Lnet/minecraft/scoreboard/ScoreboardObjective;)V", shift = At.Shift.AFTER), method = "draw")
+    private void drawScoreboardHud(float deltaTime, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_hud_scoreboard");
+        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.SCOREBOARD, this.scoreboardHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/ChatHud;draw(I)V", shift = At.Shift.AFTER), method = "draw")
+    private void drawChatHud(float deltaTime, CallbackInfo ci) {
+        this.client.getProfiler().swap("textilelib_render_hud_chat");
+        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.CHAT, this.chatHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    }
+
+    private int getMouseX() {
+        return (int) (this.client.mouse.getX() * (double) this.client.window.getScaledWidth() / (double) this.client.window.getWidth());
+    }
+
+    private int getMouseY() {
+        return (int) (this.client.mouse.getY() * (double) this.client.window.getScaledHeight() / (double) this.client.window.getHeight());
+    }
+}

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
@@ -4,7 +4,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.*;
 
 import nerdhub.textilelib.event.client.render.hud.DrawHudCallback;
-import nerdhub.textilelib.event.client.render.hud.VanillaHudTypes;
+import nerdhub.textilelib.event.client.render.hud.HudTypes;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -45,38 +45,44 @@ public abstract class MixinInGameHud {
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SpectatorHud;draw(F)V", shift = At.Shift.AFTER), method = "draw")
     private void drawSpectatorHud(float deltaTime, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_hud_spectator");
-        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.SPECTATOR, this.spectatorHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudSpectator");
+        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.SPECTATOR, this.spectatorHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/BossBarHud;draw()V", shift = At.Shift.AFTER), method = "draw")
     private void drawBossBarHud(float deltaTime, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_hud_bossbar");
-        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.BOSSBAR, this.bossBarHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudBossbar");
+        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.BOSSBAR, this.bossBarHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/DebugHud;draw()V", shift = At.Shift.AFTER), method = "draw")
     private void drawDebugHud(float deltaTime, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_hud_debug");
-        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.DEBUG, this.debugHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudDebug");
+        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.DEBUG, this.debugHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud;draw()V", shift = At.Shift.AFTER), method = "draw")
     private void drawSubtitlesHud(float deltaTime, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_hud_subtitles");
-        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.SUBTITLES, this.subtitlesHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudSubtitles");
+        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.SUBTITLES, this.subtitlesHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderScoreboardSidebar(Lnet/minecraft/scoreboard/ScoreboardObjective;)V", shift = At.Shift.AFTER), method = "draw")
     private void drawScoreboardHud(float deltaTime, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_hud_scoreboard");
-        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.SCOREBOARD, this.scoreboardHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudScoreboard");
+        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.SCOREBOARD, this.scoreboardHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/ChatHud;draw(I)V", shift = At.Shift.AFTER), method = "draw")
     private void drawChatHud(float deltaTime, CallbackInfo ci) {
-        this.client.getProfiler().swap("textilelib_render_hud_chat");
-        DrawHudCallback.EVENT.invoker().drawHud(VanillaHudTypes.CHAT, this.chatHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudChat");
+        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.CHAT, this.chatHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().pop();
     }
 
     private int getMouseX() {

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinInGameHud.java
@@ -2,6 +2,7 @@ package nerdhub.textilelib.mixin.client;
 
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.*;
+import net.minecraft.scoreboard.ScoreboardObjective;
 
 import nerdhub.textilelib.event.client.render.hud.DrawHudCallback;
 import nerdhub.textilelib.event.client.render.hud.HudTypes;
@@ -9,8 +10,7 @@ import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(InGameHud.class)
 public abstract class MixinInGameHud {
@@ -20,76 +20,102 @@ public abstract class MixinInGameHud {
     private MinecraftClient client;
 
     @Shadow
-    @Final
-    private DebugHud debugHud;
+    protected abstract void renderScoreboardSidebar(ScoreboardObjective scoreboardObjective_1);
 
-    @Shadow
-    @Final
-    private BossBarHud bossBarHud;
-
-    @Shadow
-    @Final
-    private SpectatorHud spectatorHud;
-
-    @Shadow
-    @Final
-    private SubtitlesHud subtitlesHud;
-
-    @Shadow
-    @Final
-    private ScoreboardHud scoreboardHud;
-
-    @Shadow
-    @Final
-    private ChatHud chatHud;
-
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SpectatorHud;draw(F)V", shift = At.Shift.AFTER), method = "draw")
-    private void drawSpectatorHud(float deltaTime, CallbackInfo ci) {
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SpectatorHud;draw(F)V"), method = "draw")
+    private void drawSpectatorHud(SpectatorHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudSpectator");
-        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.SPECTATOR, this.spectatorHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudSpectatorBefore");
+        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.SPECTATOR, hud, deltaTime)) {
+            this.client.getProfiler().swap("textilelib:renderHudSpectatorDraw");
+            hud.draw(deltaTime);
+            this.client.getProfiler().swap("textilelib:renderHudSpectatorAfter");
+            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.SPECTATOR, hud, deltaTime);
+        }
+        this.client.getProfiler().pop();
         this.client.getProfiler().pop();
     }
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/BossBarHud;draw()V", shift = At.Shift.AFTER), method = "draw")
-    private void drawBossBarHud(float deltaTime, CallbackInfo ci) {
-        this.client.getProfiler().push("textilelib:renderHudBossbar");
-        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.BOSSBAR, this.bossBarHud, this.getMouseX(), this.getMouseY(), deltaTime);
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/BossBarHud;draw()V"), method = "draw")
+    private void drawBossBarHud(BossBarHud hud, float deltaTime) {
+        this.client.getProfiler().push("textilelib:renderHudBossbarBefore");
+        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.BOSSBAR, hud, deltaTime)) {
+            this.client.getProfiler().swap("textilelib:renderHudBossbarDraw");
+            hud.draw();
+            this.client.getProfiler().swap("textilelib:renderHudBossbarAfter");
+            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.BOSSBAR, hud, deltaTime);
+        }
         this.client.getProfiler().pop();
     }
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/DebugHud;draw()V", shift = At.Shift.AFTER), method = "draw")
-    private void drawDebugHud(float deltaTime, CallbackInfo ci) {
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/DebugHud;draw()V"), method = "draw")
+    private void drawDebugHud(DebugHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudDebug");
-        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.DEBUG, this.debugHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudDebugBefore");
+        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.DEBUG, hud, deltaTime)) {
+            this.client.getProfiler().swap("textilelib:renderHudDebugDraw");
+            hud.draw();
+            this.client.getProfiler().swap("textilelib:renderHudDebugAfter");
+            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.DEBUG, hud, deltaTime);
+        }
+        this.client.getProfiler().pop();
         this.client.getProfiler().pop();
     }
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud;draw()V", shift = At.Shift.AFTER), method = "draw")
-    private void drawSubtitlesHud(float deltaTime, CallbackInfo ci) {
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/SubtitlesHud;draw()V"), method = "draw")
+    private void drawSubtitlesHud(SubtitlesHud hud, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudSubtitles");
-        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.SUBTITLES, this.subtitlesHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudSubtitlesBefore");
+        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.SUBTITLES, hud, deltaTime)) {
+            this.client.getProfiler().swap("textilelib:renderHudSubtitlesDraw");
+            hud.draw();
+            this.client.getProfiler().swap("textilelib:renderHudSubtitlesAfter");
+            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.SUBTITLES, hud, deltaTime);
+        }
+        this.client.getProfiler().pop();
         this.client.getProfiler().pop();
     }
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderScoreboardSidebar(Lnet/minecraft/scoreboard/ScoreboardObjective;)V", shift = At.Shift.AFTER), method = "draw")
-    private void drawScoreboardHud(float deltaTime, CallbackInfo ci) {
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/InGameHud;renderScoreboardSidebar(Lnet/minecraft/scoreboard/ScoreboardObjective;)V"), method = "draw")
+    private void drawScoreboardHud(InGameHud hud, ScoreboardObjective scoreboardObjective, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudScoreboard");
-        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.SCOREBOARD, this.scoreboardHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        this.client.getProfiler().push("textilelib:renderHudScoreboardBefore");
+        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.SCOREBOARD, hud.getScoreboardWidget(), deltaTime)) {
+            this.client.getProfiler().swap("textilelib:renderHudScoreboardDraw");
+            this.renderScoreboardSidebar(scoreboardObjective);
+            this.client.getProfiler().swap("textilelib:renderHudScoreboardAfter");
+            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.SCOREBOARD, hud.getScoreboardWidget(), deltaTime);
+        }
+        this.client.getProfiler().pop();
         this.client.getProfiler().pop();
     }
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/ChatHud;draw(I)V", shift = At.Shift.AFTER), method = "draw")
-    private void drawChatHud(float deltaTime, CallbackInfo ci) {
+    @Redirect(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/ChatHud;draw(I)V"), method = "draw")
+    private void drawChatHud(ChatHud hud, int int_1, float deltaTime) {
         this.client.getProfiler().push("textilelib:renderHudChat");
-        DrawHudCallback.EVENT.invoker().drawHud(HudTypes.CHAT, this.chatHud, this.getMouseX(), this.getMouseY(), deltaTime);
+        if (DrawHudCallback.EVENT_BEFORE.invoker().drawHud(HudTypes.CHAT, hud, deltaTime)) {
+            this.client.getProfiler().swap("textilelib:renderHudChatDraw");
+            hud.draw(int_1);
+            this.client.getProfiler().swap("textilelib:renderHudChatAfter");
+            DrawHudCallback.EVENT_AFTER.invoker().drawHud(HudTypes.CHAT, hud, deltaTime);
+        }
         this.client.getProfiler().pop();
     }
 
-    private int getMouseX() {
-        return (int) (this.client.mouse.getX() * (double) this.client.window.getScaledWidth() / (double) this.client.window.getWidth());
+
+    private void drawHearts() {
+        // TODO: In order to allow the cancelling the status bars, we would need to overwrite the entire thing
     }
 
-    private int getMouseY() {
-        return (int) (this.client.mouse.getY() * (double) this.client.window.getScaledHeight() / (double) this.client.window.getHeight());
+    private void drawArmor() {
+        // TODO: In order to allow the cancelling the status bars, we would need to overwrite the entire thing
+    }
+
+    private void drawAir() {
+        // TODO: In order to allow the cancelling the status bars, we would need to overwrite the entire thing
+    }
+
+    private void drawFood() {
+        // TODO: In order to allow the cancelling the status bars, we would need to overwrite the entire thing
     }
 }

--- a/src/main/java/nerdhub/textilelib/mixin/client/MixinScreen.java
+++ b/src/main/java/nerdhub/textilelib/mixin/client/MixinScreen.java
@@ -1,30 +1,24 @@
 package nerdhub.textilelib.mixin.client;
 
-import nerdhub.textilelib.event.client.render.DrawScreenCallback;
-import nerdhub.textilelib.event.client.render.tooltip.DrawStackTooltipCallback;
+import java.util.List;
+
 import net.minecraft.client.gui.Screen;
 import net.minecraft.item.ItemStack;
+
+import nerdhub.textilelib.event.client.render.tooltip.DrawStackTooltipCallback;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.List;
-
 
 @Mixin(Screen.class)
 public class MixinScreen {
 
-    //TODO hook into GameRenderer#L628 (this.client.currentScreen.draw) instead
-    @Inject(method = "draw", at = @At("RETURN"))
-    private void draw(int mouseX, int mouseY, float deltaTime, CallbackInfo ci) {
-        DrawScreenCallback.EVENT.invoker().drawScreen((Screen) (Object) this, mouseX, mouseY, deltaTime);
-    }
-
     @Inject(method = "drawStackTooltip", at = @At("HEAD"), cancellable = true)
     private void drawStackTooltip(ItemStack stack, int mouseX, int mouseY, CallbackInfo ci) {
         List<String> tooltipList = ((Screen) (Object) this).getStackTooltip(stack);
-        if(DrawStackTooltipCallback.EVENT.invoker().drawTooltip(stack, tooltipList, mouseX, mouseY)) {
+        if (DrawStackTooltipCallback.EVENT.invoker().drawTooltip(stack, tooltipList, mouseX, mouseY)) {
             ((Screen) (Object) this).drawTooltip(tooltipList, mouseX, mouseY);
         }
 

--- a/src/main/resources/mixins.textilelib.client.json
+++ b/src/main/resources/mixins.textilelib.client.json
@@ -3,10 +3,12 @@
     "package": "nerdhub.textilelib.mixin.client",
     "compatibilityLevel": "JAVA_8",
     "mixins": [
+        "MixinDebugHud",
         "MixinGameRenderer",
+        "MixinInGameHud",
+        "MixinItemStack",
         "MixinMinecraftClient",
-        "MixinScreen",
-        "MixinItemStack"
+        "MixinScreen"
     ],
     "injectors": {
         "defaultRequire": 1


### PR DESCRIPTION
Added event for adding/changing the Debug Text for Left and Right side of F3. Might need to pass if it was shift+f3 or others that show additional graphs.

With the HUD events, should they cancellable for stuff like health/armour/experience. Also, SpectatorHud gets called twice so not sure which one to target.

All these events are called AFTER or when returning
